### PR TITLE
Merge upstream 0.9.1

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -287,6 +287,7 @@ func (s *Server) Run(host, token string, insecure bool) error {
 		// This is a potential security risk if enabled in some clusters, hence the flag
 		r.Handle("/debug/store", appHandler(s.debugStoreHandler))
 	}
+	r.Handle("/{version}/meta-data/iam/security-credentials", appHandler(s.securityCredentialsHandler))
 	r.Handle("/{version}/meta-data/iam/security-credentials/", appHandler(s.securityCredentialsHandler))
 	r.Handle("/{version}/meta-data/iam/security-credentials/{role:.*}", appHandler(s.roleHandler))
 	r.Handle("/healthz", appHandler(s.healthHandler))


### PR DESCRIPTION
We're running into an issue with m5 ec2 instances that is fixed in 0.9.1

Patch notes follow.


The AWS metadata service works differently on new instance types like
m5.large and c5.large.

The behavior on old instances is that if you call:

```
169.254.169.254/latest/meta-data/iam/security-credentials
```

It will redirect to:

```
169.254.169.254/latest/meta-data/iam/security-credentials/
```

Which will respond with the IAM role name.

On new instances there is no redirect, it just responds with the IAM role name directly.

Since kube2iam didn't intercept the URL without the slash, the pod will
initially get the worker node role and then try to request credentials for that
role, which kube2iam will deny.

Fix is to intercept both versions of the URL.

Fix #127